### PR TITLE
fix: Use default mapper for reading config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.kapeta</groupId>
     <artifactId>spring-boot</artifactId>
     <packaging>jar</packaging>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Kapeta Spring Boot SDK</description>

--- a/src/main/java/com/kapeta/spring/config/KapetaDefaultConfig.java
+++ b/src/main/java/com/kapeta/spring/config/KapetaDefaultConfig.java
@@ -1,9 +1,13 @@
 package com.kapeta.spring.config;
 
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
@@ -12,6 +16,16 @@ import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
  * Default configuration for kapeta
  */
 public class KapetaDefaultConfig {
+
+    public static ObjectMapper createDefaultObjectMapper() {
+        return JsonMapper.builder()
+                .addModule(new JavaTimeModule())
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true)
+                .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+                .serializationInclusion(JsonInclude.Include.NON_NULL)
+                .build();
+    }
 
 
     /**
@@ -26,12 +40,7 @@ public class KapetaDefaultConfig {
     @Bean
     @ConditionalOnMissingBean(ObjectMapper.class)
     public ObjectMapper objectMapper() {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.findAndRegisterModules();
-        mapper.disable(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS);
-        mapper.disable(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS);
-        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-        return mapper;
+        return createDefaultObjectMapper();
     }
 
     @Bean

--- a/src/main/java/com/kapeta/spring/config/providers/KapetaConfigurationProvider.java
+++ b/src/main/java/com/kapeta/spring/config/providers/KapetaConfigurationProvider.java
@@ -96,6 +96,8 @@ public interface KapetaConfigurationProvider {
 
         private String protocol;
 
+        private String resource;
+
         private Map<String, Object> options = new HashMap<>();
 
         private Map<String, String> credentials = new HashMap<>();
@@ -148,5 +150,12 @@ public interface KapetaConfigurationProvider {
             this.credentials = credentials;
         }
 
+        public String getResource() {
+            return resource;
+        }
+
+        public void setResource(String resource) {
+            this.resource = resource;
+        }
     }
 }

--- a/src/main/java/com/kapeta/spring/config/providers/KubernetesConfigProvider.java
+++ b/src/main/java/com/kapeta/spring/config/providers/KubernetesConfigProvider.java
@@ -1,5 +1,6 @@
 package com.kapeta.spring.config.providers;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,6 +11,8 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 
+import static com.kapeta.spring.config.KapetaDefaultConfig.createDefaultObjectMapper;
+
 
 /**
  * Configuration for remotely running blocks (In Kubernetes)
@@ -19,7 +22,7 @@ import java.util.Map;
 public class KubernetesConfigProvider implements KapetaConfigurationProvider {
     private static final Logger log = LoggerFactory.getLogger(KubernetesConfigProvider.class);
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = createDefaultObjectMapper();
     private final String systemId;
     private final Environment environment;
     private Map<String, String> instanceHosts;

--- a/src/main/java/com/kapeta/spring/config/providers/LocalClusterServiceConfigProvider.java
+++ b/src/main/java/com/kapeta/spring/config/providers/LocalClusterServiceConfigProvider.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.kapeta.spring.config.ConfigUtils.getPropertiesFromYAML;
+import static com.kapeta.spring.config.KapetaDefaultConfig.createDefaultObjectMapper;
 
 
 /**
@@ -52,7 +53,7 @@ public class LocalClusterServiceConfigProvider implements KapetaConfigurationPro
 
     private final Environment environment;
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = createDefaultObjectMapper();
 
     private final SimpleHttpClient httpClient;
 


### PR DESCRIPTION
More lenient - ignores unknown properties and treats dates as longs