### PR TITLE
KAP-1755 Redirect root to open api documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.kapeta</groupId>
     <artifactId>spring-boot</artifactId>
     <packaging>jar</packaging>
-    <version>0.1.2</version>
+    <version>0.1.3</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Kapeta Spring Boot SDK</description>
@@ -150,6 +150,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.2.0</version>
+        </dependency>
+
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>

--- a/src/main/java/com/kapeta/spring/config/KapetaDefaultConfig.java
+++ b/src/main/java/com/kapeta/spring/config/KapetaDefaultConfig.java
@@ -12,7 +12,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.kapeta.spring.rest.OpenAPIRedirectController;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 
@@ -50,5 +52,11 @@ public class KapetaDefaultConfig {
     @Bean
     public KapetaController kapetaController() {
         return new KapetaController();
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "kapeta.openapi-redirect", havingValue = "true", matchIfMissing = true)
+    public OpenAPIRedirectController openAPIRedirectController() {
+        return new OpenAPIRedirectController();
     }
 }

--- a/src/main/java/com/kapeta/spring/rest/OpenAPIRedirectController.java
+++ b/src/main/java/com/kapeta/spring/rest/OpenAPIRedirectController.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 Kapeta Inc.
+ * SPDX-License-Identifier: MIT
+ */
+package com.kapeta.spring.rest;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.view.RedirectView;
+
+@RestController
+public class OpenAPIRedirectController {
+
+    @GetMapping("/")
+    @Hidden
+    public RedirectView redirectToSwaggerDocumentation() {
+        return new RedirectView("/swagger-ui/index.html");
+    }
+}


### PR DESCRIPTION
Add: Controller that redirects "/" to swagger openapi documentation (enabled by default, toggled by property 'kapeta.openapi-redirect')