### PR TITLE
feat: Add (de)serializers for Pageable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-commons</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>dev.akkinoc.spring.boot</groupId>
             <artifactId>logback-access-spring-boot-starter</artifactId>
             <version>4.0.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.kapeta</groupId>
     <artifactId>spring-boot</artifactId>
     <packaging>jar</packaging>
-    <version>0.2.1</version>
+    <version>0.3.0</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Kapeta Spring Boot SDK</description>

--- a/src/main/java/com/kapeta/spring/config/KapetaDefaultConfig.java
+++ b/src/main/java/com/kapeta/spring/config/KapetaDefaultConfig.java
@@ -11,12 +11,20 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.kapeta.spring.config.pageable.PageableDeserializer;
+import com.kapeta.spring.config.pageable.PageableSerializer;
 import com.kapeta.spring.security.AuthorizationForwarderSupplier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+import org.springframework.data.convert.WritingConverter;
+import org.springframework.data.domain.Pageable;
 
 /**
  * Default configuration for kapeta
@@ -25,14 +33,23 @@ import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 public class KapetaDefaultConfig {
 
     public static ObjectMapper createDefaultObjectMapper() {
-        return JsonMapper.builder()
+        var om = JsonMapper.builder()
                 .addModule(new JavaTimeModule())
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true)
                 .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
                 .serializationInclusion(JsonInclude.Include.NON_NULL)
                 .build();
+
+        SimpleModule pageableModule = new SimpleModule();
+        pageableModule.addSerializer(Pageable.class, new PageableSerializer());
+        pageableModule.addDeserializer(Pageable.class, new PageableDeserializer(om));
+        om.registerModule(pageableModule);
+
+        return om;
     }
+
+
 
 
     /**

--- a/src/main/java/com/kapeta/spring/config/pageable/PageableDeserializer.java
+++ b/src/main/java/com/kapeta/spring/config/pageable/PageableDeserializer.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2023 Kapeta Inc.
+ * SPDX-License-Identifier: MIT
+ */
 package com.kapeta.spring.config.pageable;
 
 import com.fasterxml.jackson.core.JacksonException;

--- a/src/main/java/com/kapeta/spring/config/pageable/PageableDeserializer.java
+++ b/src/main/java/com/kapeta/spring/config/pageable/PageableDeserializer.java
@@ -1,0 +1,54 @@
+package com.kapeta.spring.config.pageable;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.io.IOException;
+
+public class PageableDeserializer extends StdDeserializer<Pageable> {
+
+    private final ObjectMapper objectMapper;
+
+    public PageableDeserializer(ObjectMapper objectMapper) {
+        super(Pageable.class);
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Pageable deserialize(JsonParser jp, DeserializationContext deserializationContext) throws IOException, JacksonException {
+        ObjectNode source = jp.readValueAs(ObjectNode.class);
+
+        if (source.has("size") || source.has("page")) {
+            var page = source.get("page").asInt(0);
+            var size = source.get("size").asInt(30);
+            var sort = source.get("sort");
+            var pageRequest = PageRequest.of(page, size);
+            if (sort == null) {
+                return pageRequest;
+            }
+
+            var sortList = sort.elements();
+            while (sortList.hasNext()) {
+                var sortObject = sortList.next();
+                var direction = sortObject.get("direction").asText("ASC");
+                var property = sortObject.get("property").asText();
+                if (direction == null || property == null) {
+                    continue;
+                }
+
+                pageRequest = pageRequest.withSort(Sort.Direction.fromString(direction), property);
+            }
+
+            return pageRequest;
+        }
+
+        return objectMapper.convertValue(source, Pageable.class);
+    }
+}

--- a/src/main/java/com/kapeta/spring/config/pageable/PageableSerializer.java
+++ b/src/main/java/com/kapeta/spring/config/pageable/PageableSerializer.java
@@ -1,0 +1,34 @@
+package com.kapeta.spring.config.pageable;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.springframework.data.domain.Pageable;
+
+import java.io.IOException;
+
+public class PageableSerializer extends StdSerializer<Pageable> {
+
+    public PageableSerializer() {
+        super(Pageable.class);
+    }
+
+    @Override
+    public void serialize(Pageable pageable, JsonGenerator jg, SerializerProvider serializerProvider) throws IOException {
+        jg.writeStartObject();
+        jg.writeNumberField("page", pageable.getPageNumber());
+        jg.writeNumberField("size", pageable.getPageSize());
+
+        if (!pageable.getSort().isEmpty()) {
+            jg.writeArrayFieldStart("sort");
+            for (var order : pageable.getSort()) {
+                jg.writeStartObject();
+                jg.writeStringField("direction", order.getDirection().toString());
+                jg.writeStringField("property", order.getProperty());
+                jg.writeEndObject();
+            }
+            jg.writeEndArray();
+        }
+        jg.writeEndObject();
+    }
+}

--- a/src/main/java/com/kapeta/spring/config/pageable/PageableSerializer.java
+++ b/src/main/java/com/kapeta/spring/config/pageable/PageableSerializer.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2023 Kapeta Inc.
+ * SPDX-License-Identifier: MIT
+ */
 package com.kapeta.spring.config.pageable;
 
 import com.fasterxml.jackson.core.JsonGenerator;


### PR DESCRIPTION
Default format is not very useful in JSON - and loses information: 
```json
{"pageNumber":0,"pageSize":10,"sort":{"empty":false,"sorted":true,"unsorted":false},"offset":0,"paged":true,"unpaged":false}
```

This makes that:
```json
 {"page":0,"size":10,"sort":[{"direction":"ASC","property":"id"},{"direction":"DESC","property":"name"}]}
```